### PR TITLE
Modify modules.yaml for expanse/0.17.3/cpu/b to include *HOME env vars

### DIFF
--- a/etc/spack/sdsc/expanse/0.17.3/cpu/b/yamls/modules.yaml
+++ b/etc/spack/sdsc/expanse/0.17.3/cpu/b/yamls/modules.yaml
@@ -17,6 +17,9 @@ modules:
           '+openmp': omp
           'threads=openmp': omp
           '+ipl64': i64
+        environment:
+          set:
+            '{name}HOME': '{prefix}'
       intel:
         environment:
           set:


### PR DESCRIPTION
These minor changes should fix: https://github.com/sdsc/spack/issues/74. They were already implemented and deployed successfully to expanse/0.17.3/gpu/b.