### PR TITLE
Modify modules.yaml for expanse/0.17.3/cpu/b to whitelist py-jupyter-…

### DIFF
--- a/etc/spack/sdsc/expanse/0.17.3/cpu/b/yamls/modules.yaml
+++ b/etc/spack/sdsc/expanse/0.17.3/cpu/b/yamls/modules.yaml
@@ -9,6 +9,7 @@ modules:
         - mpi
       hash_length: 0
       blacklist_implicits: true
+      whitelist: ['py-jupyter-core']
       naming_scheme: '{name}/{version}/{hash:7}'
       projections:
         all: '{name}/{version}/{hash:7}'


### PR DESCRIPTION
…core

This minor change allows us to explicitly generate an lmod modulefile for the py-jupyter-core Spack package that was installed implicitly as a dependency of py-jupyterlab.

See https://github.com/sdsc/spack/issues/80