### PR TITLE
Add wannier90@3.1.0 % gcc@10.2.0 ^openmpi@4.1.3 to expanse/0.17.3/cpu/b

### DIFF
--- a/etc/spack/sdsc/expanse/0.17.3/cpu/b/specs/gcc@10.2.0/openmpi@4.1.3/wannier90@3.1.0.sh
+++ b/etc/spack/sdsc/expanse/0.17.3/cpu/b/specs/gcc@10.2.0/openmpi@4.1.3/wannier90@3.1.0.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+#SBATCH --job-name=wannier90@3.1.0
+#SBATCH --account=use300
+#SBATCH --reservation=root_73
+#SBATCH --partition=ind-shared
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=16
+#SBATCH --mem=32G
+#SBATCH --time=00:30:00
+#SBATCH --output=%x.o%j.%N
+
+declare -xr LOCAL_TIME="$(date +'%Y%m%dT%H%M%S%z')"
+declare -xir UNIX_TIME="$(date +'%s')"
+
+declare -xr LOCAL_SCRATCH_DIR="/scratch/${USER}/job_${SLURM_JOB_ID}"
+declare -xr TMPDIR="${LOCAL_SCRATCH_DIR}"
+
+declare -xr SYSTEM_NAME='expanse'
+
+declare -xr SPACK_VERSION='0.17.3'
+declare -xr SPACK_INSTANCE_NAME='cpu'
+declare -xr SPACK_INSTANCE_VERSION='b'
+declare -xr SPACK_INSTANCE_DIR="/cm/shared/apps/spack/${SPACK_VERSION}/${SPACK_INSTANCE_NAME}/${SPACK_INSTANCE_VERSION}"
+
+declare -xr SLURM_JOB_SCRIPT="$(scontrol show job ${SLURM_JOB_ID} | awk -F= '/Command=/{print $2}')"
+declare -xr SLURM_JOB_MD5SUM="$(md5sum ${SLURM_JOB_SCRIPT})"
+
+declare -xr SCHEDULER_MODULE='slurm'
+
+echo "${UNIX_TIME} ${SLURM_JOB_ID} ${SLURM_JOB_MD5SUM} ${SLURM_JOB_DEPENDENCY}" 
+echo ""
+
+cat "${SLURM_JOB_SCRIPT}"
+
+module purge
+module load "${SCHEDULER_MODULE}"
+module list
+. "${SPACK_INSTANCE_DIR}/share/spack/setup-env.sh"
+shopt -s expand_aliases
+source ~/.bashrc
+
+declare -xr SPACK_PACKAGE='wannier90@3.1.0'
+declare -xr SPACK_COMPILER='gcc@10.2.0'
+declare -xr SPACK_VARIANTS='+shared'
+declare -xr SPACK_DEPENDENCIES="^openblas@0.3.18/$(spack find --format '{hash:7}' openblas@0.3.18 % ${SPACK_COMPILER} +ilp64 threads=none) ^openmpi@4.1.3/$(spack find --format '{hash:7}' openmpi@4.1.3 % ${SPACK_COMPILER})"
+declare -xr SPACK_SPEC="${SPACK_PACKAGE} % ${SPACK_COMPILER} ${SPACK_VARIANTS} ${SPACK_DEPENDENCIES}"
+
+printenv
+
+spack config get compilers  
+spack config get config  
+spack config get mirrors
+spack config get modules
+spack config get packages
+spack config get repos
+spack config get upstreams
+
+time -p spack spec --long --namespaces --types --reuse "${SPACK_SPEC}"
+if [[ "${?}" -ne 0 ]]; then
+  echo 'ERROR: spack concretization failed.'
+  exit 1
+fi
+
+time -p spack install --jobs "${SLURM_CPUS_PER_TASK}" --fail-fast --yes-to-all --reuse "${SPACK_SPEC}"
+if [[ "${?}" -ne 0 ]]; then
+  echo 'ERROR: spack install failed.'
+  exit 1
+fi
+
+spack module lmod refresh -y
+
+#sbatch --dependency="afterok:${SLURM_JOB_ID}" ''
+
+sleep 30

--- a/var/spack/repos/sdsc/packages/wannier90/make.sys
+++ b/var/spack/repos/sdsc/packages/wannier90/make.sys
@@ -1,0 +1,7 @@
+F90 = @F90
+COMMS=mpi
+MPIF90=@MPIF90
+FCOPTS=-O2 -fpic
+LDOPTS=-O2 -fpic
+
+LIBS = @LIBS

--- a/var/spack/repos/sdsc/packages/wannier90/package.py
+++ b/var/spack/repos/sdsc/packages/wannier90/package.py
@@ -1,0 +1,199 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import inspect
+import os.path
+
+from spack import *
+
+
+class Wannier90(MakefilePackage):
+    """Wannier90 calculates maximally-localised Wannier functions (MLWFs).
+
+    Wannier90 is released under the GNU General Public License.
+    """
+
+    homepage = "http://wannier.org"
+    url = "https://github.com/wannier-developers/wannier90/archive/v3.1.0.tar.gz"
+    git = "https://github.com/wannier-developers/wannier90.git"
+
+    version("develop", branch="develop")
+    version("3.1.0", sha256="40651a9832eb93dec20a8360dd535262c261c34e13c41b6755fa6915c936b254")
+    version("3.0.0", sha256="f196e441dcd7b67159a1d09d2d7de2893b011a9f03aab6b30c4703ecbf20fe5b")
+    version("2.1.0", sha256="ee90108d4bc4aa6a1cf16d72abebcb3087cf6c1007d22dda269eb7e7076bddca")
+    version("2.0.1", sha256="05ea7cd421a219ce19d379ad6ae3d9b1a84be4ffb367506ffdfab1e729309e94")
+
+    depends_on("mpi")
+    depends_on("lapack")
+    depends_on("blas")
+
+    parallel = False
+
+    variant("shared", default=True, description="Builds a shared version of the library")
+
+    @property
+    def build_targets(self):
+        targets = []
+        if "@:2" in self.spec:
+            targets = ["lib", "wannier", "post", "w90chk2chk", "w90vdw", "w90pov"]
+        if "@3:" in self.spec:
+            targets = ["wannier", "post", "lib", "w90chk2chk", "w90vdw"]
+            if "+shared" in self.spec:
+                targets.append("dynlib")
+
+        return targets
+
+    def url_for_version(self, version):
+        if version > Version("2"):
+            url = "https://github.com/wannier-developers/wannier90/archive/v{0}.tar.gz"
+        else:
+            url = "http://wannier.org/code/wannier90-{0}.tar.gz"
+        return url.format(version)
+
+    @property
+    def makefile_name(self):
+        # Version 2.0.1 uses make.sys,
+        # other verions use make.inc
+        if self.spec.satisfies("@2.0.1"):
+            filename = "make.sys"
+        else:
+            filename = "make.inc"
+
+        abspath = join_path(self.stage.source_path, filename)
+        return abspath
+
+    def edit(self, spec, prefix):
+        lapack = self.spec["lapack"].libs
+        blas = self.spec["blas"].libs
+        mpi = self.spec["mpi"].libs
+
+        substitutions = {
+            "@F90": spack_fc,
+            "@MPIF90": self.spec["mpi"].mpifc,
+            "@LIBS": (lapack + blas + mpi).joined(),
+        }
+
+        template = join_path(os.path.dirname(inspect.getmodule(self).__file__), "make.sys")
+
+        copy(template, self.makefile_name)
+        for key, value in substitutions.items():
+            filter_file(key, value, self.makefile_name)
+
+        if self.spec.satisfies("%gcc@10:"):
+            fflags = ["-fallow-argument-mismatch"]
+            filter_file(r"(^FCOPTS=.*)", r"\1 {0}".format(" ".join(fflags)), self.makefile_name)
+
+        if "@:2 +shared" in self.spec:
+            # this is to build a .shared wannier90 library
+            filter_file(
+                "LIBRARY = ../../libwannier.a",
+                "LIBRARY = ../../libwannier." + dso_suffix,
+                join_path(self.stage.source_path, "src/Makefile.2"),
+            )
+            filter_file(
+                "parameters.o kmesh.o io.o comms.o "
+                "utility.o get_oper.o constants.o "
+                "postw90_common.o wan_ham.o spin.o "
+                "dos.o berry.o kpath.o kslice.o "
+                "boltzwann.o geninterp.o",
+                "comms.o get_oper.o postw90_common.o "
+                "wan_ham.o spin.o dos.o berry.o "
+                "kpath.o kslice.o boltzwann.o geninterp.o",
+                join_path(self.stage.source_path, "src/Makefile.2"),
+            )
+            filter_file(
+                "../../wannier90.x: .*",
+                "../../wannier90.x: $(OBJS) " "../wannier_prog.F90 $(LIBRARY)",
+                join_path(self.stage.source_path, "src/Makefile.2"),
+            )
+            filter_file(
+                "../../postw90.x: $(OBJS_POST) " "$(POSTDIR)postw90.F90",
+                "../../postw90.x: $(OBJS_POST) " "$(POSTDIR)postw90.F90 $(LIBRARY)",
+                join_path(self.stage.source_path, "src/Makefile.2"),
+                string=True,
+            )
+            filter_file(
+                "$(COMPILER) ../wannier_prog.F90 "
+                "$(LDOPTS) $(OBJS) $(LIBS) "
+                "-o ../../wannier90.x",
+                "$(COMPILER) -I../obj ../wannier_prog.F90 "
+                "$(LDOPTS) -L../.. -lwannier "
+                "-o ../../wannier90.x",
+                join_path(self.stage.source_path, "src/Makefile.2"),
+                string=True,
+            )
+            filter_file(
+                "$(COMPILER) $(POSTDIR)postw90.F90 "
+                "$(POSTOPTS) $(LDOPTS) "
+                "$(OBJS_POST) "
+                "$(LIBS) -o ../../postw90.x",
+                "$(COMPILER) -I../obj $(POSTDIR)postw90.F90 "
+                "$(POSTOPTS) $(LDOPTS) $(OBJS_POST) "
+                "-L../.. -lwannier $(LIBS) -o ../../postw90.x",
+                join_path(self.stage.source_path, "src/Makefile.2"),
+                string=True,
+            )
+            filter_file(
+                "$(AR) $(ARFLAGS) " "$(LIBRARY) $(OBJS2) $(OBJS)",
+                "$(MPIF90) $(FCOPTS) -shared -o " "$(LIBRARY) $(OBJS2) $(OBJS) $(LIBS)",
+                join_path(self.stage.source_path, "src/Makefile.2"),
+                string=True,
+            )
+
+    def setup_build_environment(self, env):
+        env.set("MPIFC", self.prefix.bin.mpifc)
+
+    def install(self, spec, prefix):
+        mkdirp(self.prefix.bin)
+        mkdirp(self.prefix.lib)
+        if "+shared" in spec:
+            mkdirp(self.prefix.modules)
+
+        install(
+            join_path(self.stage.source_path, "wannier90.x"),
+            join_path(self.prefix.bin, "wannier90.x"),
+        )
+
+        install(
+            join_path(self.stage.source_path, "postw90.x"), join_path(self.prefix.bin, "postw90.x")
+        )
+
+        inst = []
+        if "+shared" in spec:
+            inst.append("libwannier." + dso_suffix)
+        # version 3 or 2 without the shared variant
+        # also has a .a version of the library
+        if "@3:" in spec or "~shared" in spec:
+            inst.append("libwannier.a")
+
+        for file in inst:
+            install(join_path(self.stage.source_path, file), join_path(self.prefix.lib, file))
+
+        install(
+            join_path(self.stage.source_path, "w90chk2chk.x"),
+            join_path(self.prefix.bin, "w90chk2chk.x"),
+        )
+
+        install(
+            join_path(self.stage.source_path, "utility", "w90vdw", "w90vdw.x"),
+            join_path(self.prefix.bin, "w90vdw.x"),
+        )
+
+        if spec.satisfies("@:2"):
+            install(
+                join_path(self.stage.source_path, "utility", "w90pov", "w90pov"),
+                join_path(self.prefix.bin, "w90pov"),
+            )
+
+        install_tree(
+            join_path(self.stage.source_path, "pseudo"), join_path(self.prefix.bin, "pseudo")
+        )
+
+        for file in find(join_path(self.stage.source_path, "src/obj"), "*.mod"):
+            install(file, self.prefix.modules)
+
+    @property
+    def libs(self):
+        return find_libraries("libwannier", self.prefix, shared=True, recursive=True)


### PR DESCRIPTION
Also included is an updated package.py file for wannier90 in the custom sdsc package repo. This updated version is based on wannier90 package.py file available in the spack/spack upstream on the date of this commite. This fixes a build issue encountered with the builtins version available in Spack v0.17.3. The fix was provided in this commit [1].

[1] https://github.com/spack/spack/commit/8332a5919483ed82cf65ba6f541b85ece2a75322