### PR TITLE
Add gromacs@2022.6 % gcc@10.2.0 ^openmpi@4.1.3 to expanse/0.17.3/gpu/b

### DIFF
--- a/etc/spack/sdsc/expanse/0.17.3/gpu/b/specs/gcc@10.2.0/openmpi@4.1.3/gromacs@2022.6.sh
+++ b/etc/spack/sdsc/expanse/0.17.3/gpu/b/specs/gcc@10.2.0/openmpi@4.1.3/gromacs@2022.6.sh
@@ -1,22 +1,19 @@
 #!/usr/bin/env bash
 
-#SBATCH --job-name=gromacs@2020.4
+#SBATCH --job-name=gromacs@2022.6
 #SBATCH --account=use300
 #SBATCH --reservation=root_73
 #SBATCH --partition=ind-gpu-shared
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=1
 #SBATCH --cpus-per-task=10
-#SBATCH --mem=93G
+#SBSTCH --mem=93G
 #SBATCH --gpus=1
 #SBATCH --time=00:30:00
 #SBATCH --output=%x.o%j.%N
 
 declare -xr LOCAL_TIME="$(date +'%Y%m%dT%H%M%S%z')"
 declare -xir UNIX_TIME="$(date +'%s')"
-
-declare -xr LOCAL_SCRATCH_DIR="/scratch/${USER}/job_${SLURM_JOB_ID}"
-declare -xr TMPDIR="${LOCAL_SCRATCH_DIR}"
 
 declare -xr SYSTEM_NAME='expanse'
 
@@ -29,6 +26,10 @@ declare -xr SLURM_JOB_SCRIPT="$(scontrol show job ${SLURM_JOB_ID} | awk -F= '/Co
 declare -xr SLURM_JOB_MD5SUM="$(md5sum ${SLURM_JOB_SCRIPT})"
 
 declare -xr SCHEDULER_MODULE='slurm'
+declare -xr COMPILER_MODULE='gcc/10.2.0'
+declare -xr MPI_MODULE='openmpi/4.1.3'
+declare -xr CUDA_MODULE='cuda/11.2.2'
+declare -xr CMAKE_MODULE='cmake/3.21.4'
 
 echo "${UNIX_TIME} ${SLURM_JOB_ID} ${SLURM_JOB_MD5SUM} ${SLURM_JOB_DEPENDENCY}" 
 echo ""
@@ -37,15 +38,21 @@ cat "${SLURM_JOB_SCRIPT}"
 
 module purge
 module load "${SCHEDULER_MODULE}"
-module list
 . "${SPACK_INSTANCE_DIR}/share/spack/setup-env.sh"
+module use "${SPACK_ROOT}/share/spack/lmod/linux-rocky8-x86_64/Core"
+module load "${COMPILER_MODULE}"
+module load "${MPI_MODULE}"
+module load "${CUDA_MODULE}"
+module load "${CMAKE_MODULE}"
+module list
+shopt -s expand_aliases
+source ~/.bashrc
 
-declare -xr SPACK_PACKAGE='gromacs@2020.4'
+declare -xr SPACK_PACKAGE='gromacs@2022.6'
 declare -xr SPACK_COMPILER='gcc@10.2.0'
-declare -xr SPACK_VARIANTS='+blas +cuda ~cycle_subcounters ~double +hwloc ~ipo +lapack ~mdrun_only +mpi ~nosuffix ~opencl +openmp +plumed ~relaxed_double_precision +shared ~sycl'
-declare -xr SPACK_DEPENDENCIES="^openblas@0.3.18/$(spack find --format '{hash:7}' openblas@0.3.18 % ${SPACK_COMPILER} ~ilp64 threads=none) ^fftw@3.3.10/$(spack find --format '{hash:7}' fftw@3.3.10 % ${SPACK_COMPILER} ~mpi ~openmp) ^plumed@2.6.3/$(spack find --format '{hash:7}' plumed@2.6.3 % ${SPACK_COMPILER} +mpi ^openmpi@4.1.3)"
+declare -xr SPACK_VARIANTS='+blas +cuda ~cycle_subcounters ~double +hwloc ~ipo +lapack ~mdrun_only +mpi ~nosuffix ~opencl +openmp ~plumed ~relaxed_double_precision +shared ~sycl'
+declare -xr SPACK_DEPENDENCIES="^openblas@0.3.18/$(spack find --format '{hash:7}' openblas@0.3.18 % ${SPACK_COMPILER} ~ilp64 threads=none) ^fftw@3.3.10/$(spack find --format '{hash:7}' fftw@3.3.10 % ${SPACK_COMPILER} ~mpi ~openmp) ^openmpi@4.1.3/$(spack find --format '{hash:7}' openmpi@4.1.3 % ${SPACK_COMPILER})"
 declare -xr SPACK_SPEC="${SPACK_PACKAGE} % ${SPACK_COMPILER} ${SPACK_VARIANTS} ${SPACK_DEPENDENCIES}"
-
 printenv
 
 spack config get compilers
@@ -56,21 +63,19 @@ spack config get packages
 spack config get repos
 spack config get upstreams
 
-time -p spack spec --long --namespaces --types "${SPACK_SPEC}"
+time -p spack spec --long --namespaces --types --reuse $(echo "${SPACK_SPEC}")
 if [[ "${?}" -ne 0 ]]; then
   echo 'ERROR: spack concretization failed.'
-  exit 1
 fi
 
-time -p spack install --jobs "${SLURM_CPUS_PER_TASK}" --fail-fast --yes-to-all "${SPACK_SPEC}"
+time -p spack install -v --jobs "${SLURM_CPUS_PER_TASK}" --fail-fast --yes-to-all --reuse $(echo "${SPACK_SPEC}")
 if [[ "${?}" -ne 0 ]]; then
   echo 'ERROR: spack install failed.'
   exit 1
 fi
 
-#spack module lmod refresh --delete-tree -y
+spack module lmod refresh --delete-tree -y
 
-sbatch --dependency="afterok:${SLURM_JOB_ID}" 'gromacs@2022.6.sh'
 #sbatch --dependency="afterok:${SLURM_JOB_ID}" 'kokkos@3.4.01.sh'
 
 sleep 30

--- a/var/spack/repos/sdsc/packages/gromacs/gmxDetectCpu-cmake-3.14.patch
+++ b/var/spack/repos/sdsc/packages/gromacs/gmxDetectCpu-cmake-3.14.patch
@@ -1,0 +1,12 @@
+--- a/cmake/gmxDetectCpu.cmake
++++ b/cmake/gmxDetectCpu.cmake
+@@ -83,7 +83,7 @@ function(gmx_run_cpu_detection TYPE)
+                 set(GCC_INLINE_ASM_DEFINE "-DGMX_X86_GCC_INLINE_ASM=0")
+             endif()
+ 
+-            set(_compile_definitions "${GCC_INLINE_ASM_DEFINE} -I${PROJECT_SOURCE_DIR}/src -DGMX_CPUINFO_STANDALONE ${GMX_STDLIB_CXX_FLAGS} -DGMX_TARGET_X86=${GMX_TARGET_X86_VALUE}")
++            set(_compile_definitions ${GCC_INLINE_ASM_DEFINE} -I${PROJECT_SOURCE_DIR}/src -DGMX_CPUINFO_STANDALONE ${GMX_STDLIB_CXX_FLAGS} -DGMX_TARGET_X86=${GMX_TARGET_X86_VALUE})
+             set(LINK_LIBRARIES "${GMX_STDLIB_LIBRARIES}")
+             try_compile(CPU_DETECTION_COMPILED
+                 "${PROJECT_BINARY_DIR}"
+

--- a/var/spack/repos/sdsc/packages/gromacs/gmxDetectSimd-cmake-3.14.patch
+++ b/var/spack/repos/sdsc/packages/gromacs/gmxDetectSimd-cmake-3.14.patch
@@ -1,0 +1,11 @@
+--- a/cmake/gmxDetectSimd.cmake
++++ b/cmake/gmxDetectSimd.cmake
+@@ -77,7 +77,7 @@ function(gmx_suggest_simd _suggested_simd)
+     else()
+         set(GMX_TARGET_X86_VALUE 0)
+     endif()
+-    set(_compile_definitions "${GCC_INLINE_ASM_DEFINE} -I${CMAKE_SOURCE_DIR}/src -DGMX_CPUINFO_STANDALONE ${GMX_STDLIB_CXX_FLAGS} -DGMX_TARGET_X86=${GMX_TARGET_X86_VALUE}")
++    set(_compile_definitions ${GCC_INLINE_ASM_DEFINE} -I${CMAKE_SOURCE_DIR}/src -DGMX_CPUINFO_STANDALONE ${GMX_STDLIB_CXX_FLAGS} -DGMX_TARGET_X86=${GMX_TARGET_X86_VALUE})
+ 
+     # Prepare a default suggestion
+     set(OUTPUT_SIMD "None")

--- a/var/spack/repos/sdsc/packages/gromacs/package.py
+++ b/var/spack/repos/sdsc/packages/gromacs/package.py
@@ -1,0 +1,430 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+
+
+class Gromacs(CMakePackage):
+    """GROMACS (GROningen MAchine for Chemical Simulations) is a molecular
+    dynamics package primarily designed for simulations of proteins, lipids
+    and nucleic acids. It was originally developed in the Biophysical
+    Chemistry department of University of Groningen, and is now maintained
+    by contributors in universities and research centers across the world.
+
+    GROMACS is one of the fastest and most popular software packages
+    available and can run on CPUs as well as GPUs. It is free, open source
+    released under the GNU General Public License. Starting from version 4.6,
+    GROMACS is released under the GNU Lesser General Public License.
+    """
+
+    homepage = 'http://www.gromacs.org'
+    url      = 'https://ftp.gromacs.org/gromacs/gromacs-5.1.2.tar.gz'
+    git      = 'https://github.com/gromacs/gromacs.git'
+    maintainers = ['junghans', 'marvinbernhardt']
+
+    version('master', branch='m75d277138475679dd3e334e384a71516570cde767310476687f2a5b72333ea41aster')
+    version("2023.1", sha256="eef2bb4a6cb6314cf9da47f26df2a0d27af4bf7b3099723d43601073ab0a42f4")
+    version("2023", sha256="ac92c6da72fbbcca414fd8a8d979e56ecf17c4c1cdabed2da5cfb4e7277b7ba8")
+    version("2022.6", sha256="75d277138475679dd3e334e384a71516570cde767310476687f2a5b72333ea41")
+    version("2022.5", sha256="083cc3c424bb93ffe86c12f952e3e5b4e6c9f6520de5338761f24b75e018c223")
+    version("2022.4", sha256="c511be602ff29402065b50906841def98752639b92a95f1b0a1060d9b5e27297")
+    version("2022.3", sha256="14cfb130ddaf8f759a3af643c04f5a0d0d32b09bc3448b16afa5b617f5e35dae")
+    version("2022.2", sha256="656404f884d2fa2244c97d2a5b92af148d0dbea94ad13004724b3fcbf45e01bf")
+    version("2022.1", sha256="85ddab5197d79524a702c4959c2c43be875e0fc471df3a35224939dce8512450")
+    version("2022", sha256="fad60d606c02e6164018692c6c9f2c159a9130c2bf32e8c5f4f1b6ba2dda2b68")
+    version("2021.7", sha256="4db7bbbfe5424de48373686ec0e8c5bfa7175d5cd74290ef1c1e840e6df67f06")
+    version("2021.6", sha256="52df2c1d7586fd028d9397985c68bd6dd26e6e905ead382b7e6c473d087902c3")
+    version("2021.5", sha256="eba63fe6106812f72711ef7f76447b12dd1ee6c81b3d8d4d0e3098cd9ea009b6")
+    version("2021.4", sha256="cb708a3e3e83abef5ba475fdb62ef8d42ce8868d68f52dafdb6702dc9742ba1d")
+    version('2021.3', sha256='e109856ec444768dfbde41f3059e3123abdb8fe56ca33b1a83f31ed4575a1cc6')
+    version('2021.2', sha256='d940d865ea91e78318043e71f229ce80d32b0dc578d64ee5aa2b1a4be801aadb')
+    version('2021.1', sha256='bc1d0a75c134e1fb003202262fe10d3d32c59bbb40d714bc3e5015c71effe1e5')
+    version('2021', sha256='efa78ab8409b0f5bf0fbca174fb8fbcf012815326b5c71a9d7c385cde9a8f87b')
+    version('2020.6', sha256='d8bbe57ed3c9925a8cb99ecfe39e217f930bed47d5268a9e42b33da544bdb2ee')
+    version('2020.5', sha256='7b6aff647f7c8ee1bf12204d02cef7c55f44402a73195bd5f42cf11850616478')
+    version('2020.4', sha256='5519690321b5500c7951aaf53ff624042c3edd1a5f5d6dd1f2d802a3ecdbf4e6')
+    version('2020.3', sha256='903183691132db14e55b011305db4b6f4901cc4912d2c56c131edfef18cc92a9')
+    version('2020.2', sha256='7465e4cd616359d84489d919ec9e4b1aaf51f0a4296e693c249e83411b7bd2f3')
+    version('2020.1', sha256='e1666558831a3951c02b81000842223698016922806a8ce152e8f616e29899cf')
+    version('2020', sha256='477e56142b3dcd9cb61b8f67b24a55760b04d1655e8684f979a75a5eec40ba01')
+    version('2019.6', sha256='bebe396dc0db11a9d4cc205abc13b50d88225617642508168a2195324f06a358')
+    version('2019.5', sha256='438061a4a2d45bbb5cf5c3aadd6c6df32d2d77ce8c715f1c8ffe56156994083a')
+    version('2019.4', sha256='ba4366eedfc8a1dbf6bddcef190be8cd75de53691133f305a7f9c296e5ca1867')
+    version('2019.3', sha256='4211a598bf3b7aca2b14ad991448947da9032566f13239b1a05a2d4824357573')
+    version('2019.2', sha256='bcbf5cc071926bc67baa5be6fb04f0986a2b107e1573e15fadcb7d7fc4fb9f7e')
+    version('2019.1', sha256='b2c37ed2fcd0e64c4efcabdc8ee581143986527192e6e647a197c76d9c4583ec')
+    version('2019', sha256='c5b281a5f0b5b4eeb1f4c7d4dc72f96985b566561ca28acc9c7c16f6ee110d0b')
+    version('2018.8', sha256='776923415df4bc78869d7f387c834141fdcda930b2e75be979dc59ecfa6ebecf')
+    version('2018.5', sha256='32261df6f7ec4149fc0508f9af416953d056e281590359838c1ed6644ba097b8')
+    version('2018.4', sha256='6f2ee458c730994a8549d6b4f601ecfc9432731462f8bd4ffa35d330d9aaa891')
+    version('2018.3', sha256='4423a49224972969c52af7b1f151579cea6ab52148d8d7cbae28c183520aa291')
+    version('2018.2', sha256='4bdde8120c510b6543afb4b18f82551fddb11851f7edbd814aa24022c5d37857')
+    version('2018.1', sha256='4d3533340499323fece83b4a2d4251fa856376f2426c541e00b8e6b4c0d705cd')
+    version('2018',   sha256='deb5d0b749a52a0c6083367b5f50a99e08003208d81954fb49e7009e1b1fd0e9')
+    version('2016.6', sha256='bac0117d2cad21f9b94fe5b854fb9ae7435b098a6da4e732ee745f18e52473d7')
+    version('2016.5', sha256='57db26c6d9af84710a1e0c47a1f5bf63a22641456448dcd2eeb556ebd14e0b7c')
+    version('2016.4', sha256='4be9d3bfda0bdf3b5c53041e0b8344f7d22b75128759d9bfa9442fe65c289264')
+    version('2016.3', sha256='7bf00e74a9d38b7cef9356141d20e4ba9387289cbbfd4d11be479ef932d77d27')
+    version('5.1.5',  sha256='c25266abf07690ecad16ed3996899b1d489cbb1ef733a1befb3b5c75c91a703e')
+    version('5.1.4',  sha256='0f3793d8f1f0be747cf9ebb0b588fb2b2b5dc5acc32c3046a7bee2d2c03437bc')
+    version('5.1.2',  sha256='39d6f1d7ae8ba38cea6089da40676bfa4049a49903d21551abc030992a58f304')
+    version('4.6.7', sha256='6afb1837e363192043de34b188ca3cf83db6bd189601f2001a1fc5b0b2a214d9')
+    version('4.5.5', sha256='e0605e4810b0d552a8761fef5540c545beeaf85893f4a6e21df9905a33f871ba')
+
+    variant('mpi', default=True, description='Activate MPI support (disable for Thread-MPI support)')
+    variant('shared', default=True,
+            description='Enables the build of shared libraries')
+    variant(
+        'double', default=False,
+        description='Produces a double precision version of the executables')
+    variant('plumed', default=False, description='Enable PLUMED support')
+    variant('cuda', default=False, description='Enable CUDA support')
+    variant('opencl', default=False, description='Enable OpenCL support')
+    variant('sycl', default=False, description='Enable SYCL support')
+    variant('nosuffix', default=False, description='Disable default suffixes')
+    variant('build_type', default='RelWithDebInfo',
+            description='The build type to build',
+            values=('Debug', 'Release', 'RelWithDebInfo', 'MinSizeRel',
+                    'Reference', 'RelWithAssert', 'Profile'))
+    variant('mdrun_only', default=False,
+            description='Enables the build of a cut-down version'
+            ' of libgromacs and/or the mdrun program')
+    conflicts('+mdrun_only', when='@2021:',
+              msg='mdrun-only build option was removed for GROMACS 2021.')
+    variant('openmp', default=True,
+            description='Enables OpenMP at configure time')
+    variant('relaxed_double_precision', default=False,
+            description='GMX_RELAXED_DOUBLE_PRECISION, use only for Fujitsu PRIMEHPC')
+    conflicts('+relaxed_double_precision', when='@2021:',
+              msg='GMX_RELAXED_DOUBLE_PRECISION option removed for GROMACS 2021.')
+    variant('hwloc', default=True,
+            description='Use the hwloc portable hardware locality library')
+    variant('lapack', default=False,
+            description='Enables an external LAPACK library')
+    variant('blas', default=False,
+            description='Enables an external BLAS library')
+    variant('cycle_subcounters', default=False,
+            description='Enables cycle subcounters')
+
+    depends_on('mpi', when='+mpi')
+
+    # Plumed 2.7.2 needs Gromacs 2021, 2020.6, 2019.6
+    # Plumed 2.7.1 needs Gromacs 2021, 2020.5, 2019.6
+    # Plumed 2.7.0 needs Gromacs       2020.4, 2019.6
+    # Plumed 2.6.3 needs Gromacs       2020.4, 2019.6, 2018.8
+    # Plumed 2.6.2 needs Gromacs       2020.4, 2019.6, 2018.8
+    # Plumed 2.6.1 needs Gromacs       2020.2, 2019.6, 2018.8
+    # Plumed 2.6.0 needs Gromacs               2019.4, 2018.8
+    # Plumed 2.5.7 needs Gromacs               2019.4, 2018.8, 2016.6
+    # Plumed 2.5.6 needs Gromacs               2019.4, 2018.8, 2016.6
+    # Plumed 2.5.5 needs Gromacs               2019.4, 2018.8, 2016.6
+    # Plumed 2.5.4 needs Gromacs               2019.4, 2018.8, 2016.6
+    # Plumed 2.5.3 needs Gromacs               2019.4, 2018.8, 2016.6
+    # Plumed 2.5.2 needs Gromacs               2019.2, 2018.6, 2016.6
+    # Plumed 2.5.1 needs Gromacs                       2018.6, 2016.6
+    # Plumed 2.5.0 needs Gromacs                       2018.4, 2016.5
+
+    # Above dependencies can be verified, and new versions added, by going to
+    # https://github.com/plumed/plumed2/tree/v2.7.1/patches
+    # and switching tags.
+
+    depends_on('plumed+mpi', when='+plumed+mpi')
+    depends_on('plumed~mpi', when='+plumed~mpi')
+    depends_on('plumed@2.7.1:2.7.2+mpi', when='@2021+plumed+mpi')
+    depends_on('plumed@2.7.1:2.7.2~mpi', when='@2021+plumed~mpi')
+    depends_on('plumed@2.7.2+mpi', when='@2020.6+plumed+mpi')
+    depends_on('plumed@2.7.2~mpi', when='@2020.6+plumed~mpi')
+    depends_on('plumed@2.7.1+mpi', when='@2020.5+plumed+mpi')
+    depends_on('plumed@2.7.1~mpi', when='@2020.5+plumed~mpi')
+    depends_on('plumed@2.6.2:2.7.0+mpi', when='@2020.4+plumed+mpi')
+    depends_on('plumed@2.6.2:2.7.0~mpi', when='@2020.4+plumed~mpi')
+    depends_on('plumed@2.6.1+mpi', when='@2020.2+plumed+mpi')
+    depends_on('plumed@2.6.1~mpi', when='@2020.2+plumed~mpi')
+    depends_on('plumed@2.6.1:2.7.1+mpi', when='@2019.6+plumed+mpi')
+    depends_on('plumed@2.6.1:2.7.1~mpi', when='@2019.6+plumed~mpi')
+    depends_on('plumed@2.5.3:2.6.0+mpi', when='@2019.4+plumed+mpi')
+    depends_on('plumed@2.5.3:2.6.0~mpi', when='@2019.4+plumed~mpi')
+    depends_on('plumed@2.5.2+mpi', when='@2019.2+plumed+mpi')
+    depends_on('plumed@2.5.2~mpi', when='@2019.2+plumed~mpi')
+    depends_on('plumed@2.5.3:2.6+mpi', when='@2018.8+plumed+mpi')
+    depends_on('plumed@2.5.3:2.6~mpi', when='@2018.8+plumed~mpi')
+    depends_on('plumed@2.5.1:2.5.2+mpi', when='@2018.6+plumed+mpi')
+    depends_on('plumed@2.5.1:2.5.2~mpi', when='@2018.6+plumed~mpi')
+    depends_on('plumed@2.5.0+mpi', when='@2018.4+plumed+mpi')
+    depends_on('plumed@2.5.0~mpi', when='@2018.4+plumed~mpi')
+    depends_on('plumed@2.5.1:2.5+mpi', when='@2016.6+plumed+mpi')
+    depends_on('plumed@2.5.1:2.5~mpi', when='@2016.6+plumed~mpi')
+    depends_on('plumed@2.5.0+mpi', when='@2016.5+plumed+mpi')
+    depends_on('plumed@2.5.0~mpi', when='@2016.5+plumed~mpi')
+
+    depends_on('fftw-api@3')
+    depends_on('cmake@2.8.8:3', type='build')
+    depends_on('cmake@3.4.3:3', type='build', when='@2018:')
+    depends_on('cmake@3.9.6:3', type='build', when='@2020')
+    depends_on('cmake@3.13.0:3', type='build', when='@2021:')
+    depends_on('cmake@3.16.0:3', type='build', when='@master')
+    depends_on('cmake@3.16.0:3', type='build', when='%fj')
+    depends_on('cuda', when='+cuda')
+    depends_on('sycl', when='+sycl')
+    depends_on('lapack', when='+lapack')
+    depends_on('blas', when='+blas')
+
+    depends_on('hwloc@1.0:1', when='+hwloc@2016:2018')
+    depends_on('hwloc', when='+hwloc@2019:')
+
+    patch('gmxDetectCpu-cmake-3.14.patch', when='@2018:2019.3^cmake@3.14.0:')
+    patch('gmxDetectSimd-cmake-3.14.patch', when='@5.0:2017^cmake@3.14.0:')
+
+    filter_compiler_wrappers(
+        '*.cmake',
+        relative_root=os.path.join('share', 'cmake', 'gromacs_mpi'))
+    filter_compiler_wrappers(
+        '*.cmake',
+        relative_root=os.path.join('share', 'cmake', 'gromacs'))
+
+    def patch(self):
+        # Otherwise build fails with GCC 11 (11.2)
+        if self.spec.satisfies('@2018:2020.6'):
+            filter_file('#include <vector>', '#include <vector>\n#include <limits>',
+                        'src/gromacs/awh/biasparams.h')
+        if self.spec.satisfies('@2018:2018.8'):
+            filter_file('#include <vector>', '#include <vector>\n#include <limits>',
+                        'src/gromacs/mdlib/minimize.cpp')
+        if self.spec.satisfies('@2019:2019.6,2020:2020.6'):
+            filter_file('#include <vector>', '#include <vector>\n#include <limits>',
+                        'src/gromacs/mdrun/minimize.cpp')
+        if self.spec.satisfies('@2020:2020.6'):
+            filter_file('#include <queue>', '#include <queue>\n#include <limits>',
+                        'src/gromacs/modularsimulator/modularsimulator.h')
+
+        if '+plumed' in self.spec:
+            self.spec['plumed'].package.apply_patch(self)
+
+        if self.spec.satisfies('%nvhpc'):
+            # Disable obsolete workaround
+            filter_file('ifdef __PGI', 'if 0', 'src/gromacs/fileio/xdrf.h')
+
+        if '+cuda' in self.spec:
+            # Upstream supports building of last two major versions of Gromacs.
+            # Older versions of Gromacs need to be patched to build with more recent
+            # versions of CUDA library.
+
+            # Hardware version 3.0 is supported up to CUDA 10.2 (Gromacs 4.6-2020.3
+            # needs to be patched, 2020.4 is handling it correctly)
+
+            if self.spec.satisfies('@4.6:2020.3^cuda@11:'):
+                filter_file(r'-gencode;arch=compute_30,code=sm_30;?', '',
+                            'cmake/gmxManageNvccConfig.cmake')
+                filter_file(r'-gencode;arch=compute_30,code=compute_30;?', '',
+                            'cmake/gmxManageNvccConfig.cmake')
+
+            # Hardware version 2.0 is supported up to CUDA 8 (Gromacs 4.6-2016.3
+            # needs to be patched, 2016.4 is handling it correctly, removed in 2019)
+
+            if self.spec.satisfies('@4.6:2016.3^cuda@9:'):
+                filter_file(r'-gencode;arch=compute_20,code=sm_20;?', '',
+                            'cmake/gmxManageNvccConfig.cmake')
+                filter_file(r'-gencode;arch=compute_20,code=compute_20;?', '',
+                            'cmake/gmxManageNvccConfig.cmake')
+
+            if self.spec.satisfies('@4.6:5.0^cuda@9:'):
+                filter_file(r'-gencode;arch=compute_20,code=sm_21;?', '',
+                            'cmake/gmxManageNvccConfig.cmake')
+
+    def cmake_args(self):
+
+        options = []
+
+        if '+mpi' in self.spec:
+            options.append('-DGMX_MPI:BOOL=ON')
+            if self.version < Version('2020'):
+                # Ensures gmxapi builds properly
+                options.extend([
+                    '-DCMAKE_C_COMPILER=%s' % self.spec['mpi'].mpicc,
+                    '-DCMAKE_CXX_COMPILER=%s' % self.spec['mpi'].mpicxx,
+                    '-DCMAKE_Fortran_COMPILER=%s' % self.spec['mpi'].mpifc,
+                ])
+            elif self.version == Version('2021'):
+                # Work around https://gitlab.com/gromacs/gromacs/-/issues/3896
+                # Ensures gmxapi builds properly
+                options.extend([
+                    '-DCMAKE_C_COMPILER=%s' % self.spec['mpi'].mpicc,
+                    '-DCMAKE_CXX_COMPILER=%s' % self.spec['mpi'].mpicxx,
+                ])
+            else:
+                options.extend([
+                    '-DCMAKE_C_COMPILER=%s' % spack_cc,
+                    '-DCMAKE_CXX_COMPILER=%s' % spack_cxx,
+                    '-DMPI_C_COMPILER=%s' % self.spec['mpi'].mpicc,
+                    '-DMPI_CXX_COMPILER=%s' % self.spec['mpi'].mpicxx
+                ])
+        else:
+            options.extend([
+                '-DCMAKE_C_COMPILER=%s' % spack_cc,
+                '-DCMAKE_CXX_COMPILER=%s' % spack_cxx,
+                '-DGMX_MPI:BOOL=OFF',
+                '-DGMX_THREAD_MPI:BOOL=ON'])
+
+        if self.spec.satisfies('@2020:'):
+            options.append('-DGMX_INSTALL_LEGACY_API=ON')
+
+        if '+double' in self.spec:
+            options.append('-DGMX_DOUBLE:BOOL=ON')
+
+        if '+nosuffix' in self.spec:
+            options.append('-DGMX_DEFAULT_SUFFIX:BOOL=OFF')
+
+        if '~shared' in self.spec:
+            options.append('-DBUILD_SHARED_LIBS:BOOL=OFF')
+            options.append('-DGMXAPI:BOOL=OFF')
+
+        if '+hwloc' in self.spec:
+            options.append('-DGMX_HWLOC:BOOL=ON')
+        else:
+            options.append('-DGMX_HWLOC:BOOL=OFF')
+
+        if self.version >= Version('2021'):
+            if '+cuda' in self.spec:
+                options.append('-DGMX_GPU:STRING=CUDA')
+            elif '+opencl' in self.spec:
+                options.append('-DGMX_GPU:STRING=OpenCL')
+            elif '+sycl' in self.spec:
+                options.append('-DGMX_GPU:STRING=SYCL')
+            else:
+                options.append('-DGMX_GPU:STRING=OFF')
+        else:
+            if '+cuda' in self.spec or '+opencl' in self.spec:
+                options.append('-DGMX_GPU:BOOL=ON')
+            else:
+                options.append('-DGMX_GPU:BOOL=OFF')
+
+        if '+cuda' in self.spec:
+            options.append('-DCUDA_TOOLKIT_ROOT_DIR:STRING=' +
+                           self.spec['cuda'].prefix)
+
+        if '+opencl' in self.spec:
+            options.append('-DGMX_USE_OPENCL=on')
+
+        if '+lapack' in self.spec:
+            options.append('-DGMX_EXTERNAL_LAPACK:BOOL=ON')
+            if self.spec['lapack'].libs:
+                options.append('-DGMX_LAPACK_USER={0}'.format(
+                    self.spec['lapack'].libs.joined(';')))
+        else:
+            options.append('-DGMX_EXTERNAL_LAPACK:BOOL=OFF')
+
+        if '+blas' in self.spec:
+            options.append('-DGMX_EXTERNAL_BLAS:BOOL=ON')
+            if self.spec['blas'].libs:
+                options.append('-DGMX_BLAS_USER={0}'.format(
+                    self.spec['blas'].libs.joined(';')))
+        else:
+            options.append('-DGMX_EXTERNAL_BLAS:BOOL=OFF')
+
+        # Activate SIMD based on properties of the target
+        target = self.spec.target
+        if target >= 'zen2':
+            # AMD Family 17h (EPYC Rome)
+            options.append('-DGMX_SIMD=AVX2_256')
+        elif target >= 'zen':
+            # AMD Family 17h (EPYC Naples)
+            options.append('-DGMX_SIMD=AVX2_128')
+        elif target >= 'bulldozer':
+            # AMD Family 15h
+            options.append('-DGMX_SIMD=AVX_128_FMA')
+        elif 'vsx' in target:
+            # IBM Power 7 and beyond
+            if self.spec.satisfies('%nvhpc'):
+                options.append('-DGMX_SIMD=None')
+            else:
+                options.append('-DGMX_SIMD=IBM_VSX')
+        elif target.family == 'aarch64':
+            # ARMv8
+            if self.spec.satisfies('%nvhpc'):
+                options.append('-DGMX_SIMD=None')
+            else:
+                options.append('-DGMX_SIMD=ARM_NEON_ASIMD')
+        elif target == 'mic_knl':
+            # Intel KNL
+            options.append('-DGMX_SIMD=AVX_512_KNL')
+        else:
+            # Other architectures
+            simd_features = [
+                ('sse2', 'SSE2'),
+                ('sse4_1', 'SSE4.1'),
+                ('avx', 'AVX_256'),
+                ('axv128', 'AVX2_128'),
+                ('avx2', 'AVX2_256'),
+                ('avx512', 'AVX_512'),
+            ]
+
+            # Workaround NVIDIA compiler bug when avx512 is enabled
+            if (self.spec.satisfies('%nvhpc') and
+                ('avx512', 'AVX_512') in simd_features):
+                simd_features.remove(('avx512', 'AVX_512'))
+
+            feature_set = False
+            for feature, flag in reversed(simd_features):
+                if feature in target:
+                    options.append('-DGMX_SIMD:STRING={0}'.format(flag))
+                    feature_set = True
+                    break
+
+            # Fall back
+            if not feature_set:
+                options.append('-DGMX_SIMD:STRING=None')
+
+        # Use the 'rtdscp' assembly instruction only on
+        # appropriate architectures
+        options.append(self.define(
+            'GMX_USE_RDTSCP', str(target.family) in ('x86_64', 'x86')
+        ))
+
+        if self.spec.satisfies('@:2020'):
+            options.append(
+                self.define_from_variant('GMX_BUILD_MDRUN_ONLY', 'mdrun_only'))
+
+        options.append(self.define_from_variant('GMX_OPENMP', 'openmp'))
+
+        if self.spec.satisfies('@:2020'):
+            options.append(
+                self.define_from_variant(
+                    'GMX_RELAXED_DOUBLE_PRECISION',
+                    'relaxed_double_precision'))
+
+        if '+cycle_subcounters' in self.spec:
+            options.append('-DGMX_CYCLE_SUBCOUNTERS:BOOL=ON')
+        else:
+            options.append('-DGMX_CYCLE_SUBCOUNTERS:BOOL=OFF')
+
+        if '^mkl' in self.spec:
+            # fftw-api@3 is provided by intel-mkl or intel-parllel-studio
+            # we use the mkl interface of gromacs
+            options.append('-DGMX_FFT_LIBRARY=mkl')
+            options.append('-DMKL_INCLUDE_DIR={0}'.
+                           format(self.spec['mkl'].headers.directories[0]))
+            # The 'blas' property provides a minimal set of libraries
+            # that is sufficient for fft. Using full mkl fails the cmake test
+            options.append('-DMKL_LIBRARIES={0}'.
+                           format(self.spec['blas'].libs.joined(';')))
+        else:
+            # we rely on the fftw-api@3
+            options.append('-DGMX_FFT_LIBRARY=fftw3')
+            if '^amdfftw' in self.spec:
+                options.append('-DGMX_FFT_LIBRARY=fftw3')
+                options.append(
+                    '-DFFTWF_INCLUDE_DIRS={0}'.
+                    format(self.spec['amdfftw'].headers.directories[0])
+                )
+                options.append('-DFFTWF_LIBRARIES={0}'.
+                               format(self.spec['amdfftw'].libs.joined(';')))
+
+        # Ensure that the GROMACS log files report how the code was patched
+        # during the build, so that any problems are easier to diagnose.
+        if '+plumed' in self.spec:
+            options.append('-DGMX_VERSION_STRING_OF_FORK=PLUMED-spack')
+        else:
+            options.append('-DGMX_VERSION_STRING_OF_FORK=spack')
+        return options


### PR DESCRIPTION
A user requested an updated version of GROMACS for their work [1][2][3]. We decided it may be useful to deploy one for all users on the system in the expanse/0.17.3/gpu/b production instance. At the time of this commit, GROMACS v2022.6 was the latest release from the 2022.x version series, which was released on Tuesday, July 11th, 2023 [4].

The build was tested successfully via my shared Spack instance configuration for expanse/0.17.3/gpu/b. And the standard water benchmark performance was observed within expected ns/day ranges. We will likely deploy the same version in expanse/0.17.3/cpu/b as well to mirror the instance configruations and options as closely as possible.

[1] https://github.com/sdsc/spack/issues/100
[2] https://sdsc.zendesk.com/agent/tickets/29944
[3] https://sdsc.zendesk.com/agent/tickets/26289
[4] https://manual.gromacs.org