### PR TITLE
Add star@2.7.11b % gcc@10.2.0 to expanse/0.17.3/cpu/b

### DIFF
--- a/etc/spack/sdsc/expanse/0.17.3/cpu/b/specs/gcc@10.2.0/star@2.7.11b.sh
+++ b/etc/spack/sdsc/expanse/0.17.3/cpu/b/specs/gcc@10.2.0/star@2.7.11b.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+#SBATCH --job-name=star@2.7.11b
+#SBATCH --account=use300
+#SBATCH --partition=ind-shared
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=16
+#SBATCH --mem=32G
+#SBATCH --time=00:30:00
+#SBATCH --output=%x.o%j.%N
+
+declare -xr LOCAL_TIME="$(date +'%Y%m%dT%H%M%S%z')"
+declare -xir UNIX_TIME="$(date +'%s')"
+
+declare -xr LOCAL_SCRATCH_DIR="/scratch/${USER}/job_${SLURM_JOB_ID}"
+declare -xr TMPDIR="${LOCAL_SCRATCH_DIR}"
+
+declare -xr SYSTEM_NAME='expanse'
+
+declare -xr SPACK_VERSION='0.17.3'
+declare -xr SPACK_INSTANCE_NAME='cpu'
+declare -xr SPACK_INSTANCE_VERSION='b'
+declare -xr SPACK_INSTANCE_DIR="/cm/shared/apps/spack/${SPACK_VERSION}/${SPACK_INSTANCE_NAME}/${SPACK_INSTANCE_VERSION}"
+
+declare -xr SLURM_JOB_SCRIPT="$(scontrol show job ${SLURM_JOB_ID} | awk -F= '/Command=/{print $2}')"
+declare -xr SLURM_JOB_MD5SUM="$(md5sum ${SLURM_JOB_SCRIPT})"
+
+declare -xr SCHEDULER_MODULE='slurm'
+
+echo "${UNIX_TIME} ${SLURM_JOB_ID} ${SLURM_JOB_MD5SUM} ${SLURM_JOB_DEPENDENCY}" 
+echo ""
+
+cat "${SLURM_JOB_SCRIPT}"
+
+module purge
+module load "${SCHEDULER_MODULE}"
+module list
+. "${SPACK_INSTANCE_DIR}/share/spack/setup-env.sh"
+
+declare -xr SPACK_PACKAGE='star@2.7.11b'
+declare -xr SPACK_COMPILER='gcc@10.2.0'
+declare -xr SPACK_VARIANTS=''
+declare -xr SPACK_DEPENDENCIES=''
+declare -xr SPACK_SPEC="${SPACK_PACKAGE} % ${SPACK_COMPILER} ${SPACK_VARIANTS} ${SPACK_DEPENDENCIES}"
+
+printenv
+
+spack config get compilers  
+spack config get config  
+spack config get mirrors
+spack config get modules
+spack config get packages
+spack config get repos
+spack config get upstreams
+
+time -p spack spec --long --namespaces --types "${SPACK_SPEC}"
+if [[ "${?}" -ne 0 ]]; then
+  echo 'ERROR: spack concretization failed.'
+  exit 1
+fi
+
+time -p spack install --jobs "${SLURM_CPUS_PER_TASK}" --fail-fast --yes-to-all "${SPACK_SPEC}"
+if [[ "${?}" -ne 0 ]]; then
+  echo 'ERROR: spack install failed.'
+  exit 1
+fi

--- a/var/spack/repos/sdsc/packages/star/package.py
+++ b/var/spack/repos/sdsc/packages/star/package.py
@@ -12,6 +12,10 @@ class Star(Package):
     homepage = "https://github.com/alexdobin/STAR"
     url      = "https://github.com/alexdobin/STAR/archive/2.7.6a.tar.gz"
 
+
+    version('2.7.11b', sha256='3f65305e4112bd154c7e22b333dcdaafc681f4a895048fa30fa7ae56cac408e7')
+    version('2.7.11a', sha256='542457b1a4fee73f27a581b1776e9f73ad2b4d7e790388b6dc71147bd039f99a')
+    version('2.7.10b', sha256='0d1b71de6c5be1c5d90b32130d2abcd5785a4fc7c1e9bf19cc391947f2dc46e5')
     version('2.7.10a', sha256='af0df8fdc0e7a539b3ec6665dce9ac55c33598dfbc74d24df9dae7a309b0426a')
     version('2.7.9a', sha256='ff52c9d6daaa9fb7261efa3aa49ef6ce5262aa089b0762a3cbc751e81321050e')
     version('2.7.6a', sha256='9320797c604673debea0fe8f2e3762db364915cc59755de1a0d87c8018f97d51')


### PR DESCRIPTION
This pull request should resolve this issue [1] once the new spec build script is deployed into the production instance on Expanse. 

[1] https://github.com/sdsc/spack/issues/129